### PR TITLE
macOS build fixes for thirdparty/qrcode

### DIFF
--- a/data/fiducials/download.py
+++ b/data/fiducials/download.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import urllib
 from subprocess import call

--- a/thirdparty/qrcode/quirc/readme.md
+++ b/thirdparty/qrcode/quirc/readme.md
@@ -2,8 +2,14 @@
 
 Install dependencies
 
+Ubuntu
 ```
 sudo apt-get install libboost-all-dev
+```
+
+macOS
+```
+brew install boost
 ```
 
 Checkout and build Quirc
@@ -11,4 +17,4 @@ Checkout and build Quirc
 1) cd qrcode/quirc
 2) git clone https://github.com/dlbeer/quirc.git 
 3) cd quirc;git checkout 307473dbcab5e6c9654944c034b2426f46ac509f
-4) make libquirc.a; cd..
+4) make libquirc.a; cd ..

--- a/thirdparty/qrcode/readme.md
+++ b/thirdparty/qrcode/readme.md
@@ -33,7 +33,8 @@ If you want to rebuild everything later on you can simply run the ./build_all_li
 
 # Running the Benchmark
 
-./build_all_libraries.py
-./detect_all_libraries.py
-./evaluate_results.py
-
+- pip install shapely
+- ./build_all_libraries.py
+- ./detect_all_libraries.py
+- ./evaluate_results_count.py
+- ./evaluate_results_labeled.py

--- a/thirdparty/qrcode/zbar/build.py
+++ b/thirdparty/qrcode/zbar/build.py
@@ -11,7 +11,8 @@ check_cd(os.path.abspath(script_directory))
 
 # Build the library
 check_cd("zbar-0.10")
-run_command("find ./zbar -type f -print0 | xargs -0 sed -i 's/dprintf/zbarprintf/g'")
+run_command("find ./zbar -type f \(-iname '*.[ch]' \) -print0 | xargs -0 sed -i.bu 's/dprintf/zbarprintf/g'")
+run_command("find ./zbar -name '*.bu' -type f -delete")
 run_command("./configure --disable-video --without-gtk --without-qt --without-python --without-imagemagick")
 run_command("make -j8")
 


### PR DESCRIPTION
only run sed on .c and .h files for zbar then delete the backup files
specify to use python2 for fiducial download script
update readmes